### PR TITLE
Fix to make the app run from PHP

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -24,7 +24,7 @@ static const uint32_t packet_size = 3136;
 int main (int argc, char* argv[]) {
 
 	if (!cli(argc, argv)) {
-        QApplication a(argc, argv);
+		QApplication a(argc, argv);
 		// Watch our binary file for new packets to be parsed/stored.
 		FileHandler f(file_path, packet_size);
 
@@ -48,6 +48,4 @@ int main (int argc, char* argv[]) {
 
 		return a.exec();
 	} else { return 0; }
-
-    //return a.exec();
 }

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -22,9 +22,9 @@ static const std::string file_path = "input.bin";
 static const uint32_t packet_size = 3136;
 
 int main (int argc, char* argv[]) {
-	QApplication a(argc, argv);
 
 	if (!cli(argc, argv)) {
+        QApplication a(argc, argv);
 		// Watch our binary file for new packets to be parsed/stored.
 		FileHandler f(file_path, packet_size);
 
@@ -49,5 +49,5 @@ int main (int argc, char* argv[]) {
 		return a.exec();
 	} else { return 0; }
 
-	return a.exec();
+    //return a.exec();
 }


### PR DESCRIPTION
The cli would not run when called with `shell_exec` through PHP. It would die with this error: 


```
QXcbConnection: Could not connect to display
Aborted (core dumped)
```

I suspect QApplication needs X to run and PHP doesn't allow for that? Idk. I moved the initialization inside the cli check (and removed the second a.exec()), and it now works both through PHP and with GUI. 